### PR TITLE
Update LiveUploadOperation.cs

### DIFF
--- a/src/WinStore/Source/Public/LiveUploadOperation.cs
+++ b/src/WinStore/Source/Public/LiveUploadOperation.cs
@@ -113,8 +113,9 @@ namespace Microsoft.Live
                     {
                         progressHandler.Report(
                             new LiveOperationProgress(
-                                (long)t.Progress.BytesReceived,
-                                (long)t.Progress.TotalBytesToReceive));
+                                (long)t.Progress.BytesSent, //uploading, not downloading
+                                (long)t.Progress.TotalBytesToSend //uploading, not downloading
+                                ));
                     }
                 });
 


### PR DESCRIPTION
There is a bug in the Lambda function of progressHandlerWrapper. 
Since we are uploading we have to use ByteSent and TotalBytesToSend.
