### PR TITLE
Update LiveAuthClient.cs for NullReferenceException

### DIFF
--- a/src/WP8/Source/Public/LiveAuthClient.cs
+++ b/src/WP8/Source/Public/LiveAuthClient.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Live
         /// </summary>
         internal bool RefreshToken(Action<LiveLoginResult> completionCallback)
         {
-            if (this.Session.IsValid)
+            if (this.Session == null || this.Session.IsValid)
             {
                 return false;
             }


### PR DESCRIPTION
Avoid the following exception that is occurring in 5.6 of the LiveSDK on Windows Phone 8

Object reference not set to an instance of an object.
   at Microsoft.Live.LiveAuthClient.RefreshToken(Action`1 completionCallback)
   at Microsoft.Live.Operations.ApiOperation.RefreshTokenIfNeeded()
   at Microsoft.Live.Operations.ApiOperation.PrepareRequest()
   at Microsoft.Live.Operations.ApiOperation.OnExecute()
   at Microsoft.Live.Operations.Operation.InternalExecute()
   at Microsoft.Live.Operations.Operation.Execute()
   at Microsoft.Live.LiveConnectClient.ExecuteApiOperation(ApiOperation op, CancellationToken ct)
   at Microsoft.Live.LiveConnectClient.GetAsync(String path, CancellationToken ct)
