### PR TITLE
Add a null check if we didn't get a response

### DIFF
--- a/src/Common/Source/Internal/Utilities/LiveAuthRequestUtility.cs
+++ b/src/Common/Source/Internal/Utilities/LiveAuthRequestUtility.cs
@@ -100,7 +100,10 @@ namespace Microsoft.Live
             catch (WebException e)
             {
                 response = e.Response as HttpWebResponse;
-                loginResult = ReadResponse(response);
+                if (response != null)
+                {
+                    loginResult = ReadResponse(response);
+                }
             }
             catch (IOException ioe)
             {


### PR DESCRIPTION
If there was any trouble resolving our host information the request would
not be set, and then this would cause null refs deeper in our code.  This
wouldn't be a problem except that our tasks management system is getting
prematurely aborted which causes OnExchangeCodeCompleted never to be
triggered resulting in a stuck Authenication flow.

Fixes Bug #27 