### PR TITLE
Fix a bug where resources could not be found

### DIFF
--- a/src/WP8/Source/Internal/ResourceHelper.cs
+++ b/src/WP8/Source/Internal/ResourceHelper.cs
@@ -22,20 +22,33 @@
 
 namespace Microsoft.Live
 {
+    using System;
+    using System.Reflection;
     using System.Resources;
 
     internal static class ResourceHelper
     {
-        private static readonly ResourceManager resourceManager;
+        private static readonly ResourceManager PrimaryResourceManager;
+        private static readonly Lazy<ResourceManager> FallbackResourceManager;
 
         static ResourceHelper()
         {
-            resourceManager = new ResourceManager(typeof(Resources));
+            PrimaryResourceManager = new ResourceManager(typeof(Resources));
+            FallbackResourceManager = new Lazy<ResourceManager>(() =>
+                new ResourceManager("Microsoft.Live.Internal.Resources", Assembly.GetAssembly(typeof(Resources))));
         }
 
         public static string GetString(string name)
         {
-            return resourceManager.GetString(name);
+            try
+            {
+                return PrimaryResourceManager.GetString(name);
+            }
+            catch (MissingManifestResourceException)
+            {
+            }
+
+            return FallbackResourceManager.Value.GetString(name);
         }
     }
 }


### PR DESCRIPTION
The ResourceHelper uses the default constructor for ResourceManager this
seems to work in some platforms where the resources are inside of the
executing assembly, but this is not always the case as with the
ApiExplorer sample application.  Adding a fallback that attempts to load
the assembly.

Fix for #8 