### PR TITLE
Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Live SDK enables access to users’ identity profile info and allows your ap
 * For Windows Runtime HTML apps: Click Windows > Extension SDKs and select both Live SDK and Windows Library for JavaScript 2.1. Further details available [here](http://msdn.microsoft.com/en-us/library/dn631820.aspx)
 * For Windows Runtime XAML apps: Click Windows 8.1 or Windows Phone 8.1 > Extensions and select Live SDK. Further details available [here](http://msdn.microsoft.com/en-us/library/dn631823.aspx)
 
-To use the SDK in a Windows Store app with single sign-in (the default), you need to register the application with the Windows Store. Failing to reigster the app will generate a runtime exception when logging in with the SDK. For more information about how to register with the Windows Store, click [here](http://msdn.microsoft.com/en-US/library/dn631823.aspx#associate_your_app_with_the_store)
+To use the SDK in a Windows Store app with single sign-in (the default), you need to register the application with the Windows Store. Failing to register the app will generate a runtime exception when logging in with the SDK. For more information about how to register with the Windows Store, click [here](http://msdn.microsoft.com/en-US/library/dn631823.aspx#associate_your_app_with_the_store)
 
 
 3. Documentation

--- a/src/WP8/Source/Internal/ResourceHelper.cs
+++ b/src/WP8/Source/Internal/ResourceHelper.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Live
     internal static class ResourceHelper
     {
         private static readonly ResourceManager PrimaryResourceManager;
+#if !WINDOWS_PHONE
         private static readonly Lazy<ResourceManager> FallbackResourceManager;
+#endif
 
         static ResourceHelper()
         {

--- a/src/WP8/Source/Internal/ResourceHelper.cs
+++ b/src/WP8/Source/Internal/ResourceHelper.cs
@@ -34,8 +34,10 @@ namespace Microsoft.Live
         static ResourceHelper()
         {
             PrimaryResourceManager = new ResourceManager(typeof(Resources));
+#if !WINDOWS_PHONE
             FallbackResourceManager = new Lazy<ResourceManager>(() =>
                 new ResourceManager("Microsoft.Live.Internal.Resources", Assembly.GetAssembly(typeof(Resources))));
+#endif
         }
 
         public static string GetString(string name)
@@ -46,9 +48,14 @@ namespace Microsoft.Live
             }
             catch (MissingManifestResourceException)
             {
+#if WINDOWS_PHONE
+                throw;
+#endif
             }
 
+#if !WINDOWS_PHONE
             return FallbackResourceManager.Value.GetString(name);
+#endif
         }
     }
 }

--- a/src/WinStore/Source/Public/LiveAuthClient.cs
+++ b/src/WinStore/Source/Public/LiveAuthClient.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Live
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Globalization;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -77,7 +78,7 @@ namespace Microsoft.Live
         #endregion
 
         #region Properties
-        
+
         /// <summary>
         /// Gets and sets the theme used for the consent request.
         /// </summary>
@@ -123,7 +124,7 @@ namespace Microsoft.Live
         {
             return this.InitializeAsync(new List<string>());
         }
-        
+
         /// <summary>
         /// Initializes the auth client. Detects if user is already signed in,
         /// If user is already signed in, creates a valid Session.
@@ -132,11 +133,29 @@ namespace Microsoft.Live
         /// <param name="scopes">The list of offers that the application is requesting user consent for.</param>
         public Task<LiveLoginResult> InitializeAsync(IEnumerable<string> scopes)
         {
+            if (scopes != null)
+            {
+                return InitializeAsync(scopes.ToArray());
+            }
+            else
+            {
+                return InitializeAsync(null);
+            }
+        }
+
+        /// <summary>
+        /// Initializes the auth client. Detects if user is already signed in,
+        /// If user is already signed in, creates a valid Session.
+        /// This call is UI-less.
+        /// </summary>
+        /// <param name="scopes"></param>
+        /// <returns></returns>
+        public Task<LiveLoginResult> InitializeAsync(params string[] scopes)
+        {
             if (scopes == null)
             {
                 throw new ArgumentNullException("scopes");
             }
-
             return this.ExecuteAuthTaskAsync(scopes, true);
         }
 
@@ -146,11 +165,28 @@ namespace Microsoft.Live
         /// <param name="scopes">The list of offers that the application is requesting user consent for.</param>
         public Task<LiveLoginResult> LoginAsync(IEnumerable<string> scopes)
         {
+            if (scopes != null)
+            {
+                return LoginAsync(scopes.ToArray());
+            }
+            else
+            {
+                return LoginAsync(null);
+            }
+        }
+
+
+        /// <summary>
+        /// Displays the login/consent UI and returns a Session object when user completes the auth flow.
+        /// </summary>
+        /// <param name="scopes">The list of offers that the application is requesting user consent for.</param>
+        public Task<LiveLoginResult> LoginAsync(params string[] scopes)
+        {
             if (scopes == null && this.scopes == null)
             {
                 throw new ArgumentNullException("scopes");
             }
-            
+
             return this.ExecuteAuthTaskAsync(scopes, false);
         }
 
@@ -255,7 +291,7 @@ namespace Microsoft.Live
                 this.MergeScopes();
                 this.Session = result.Session;
             }
-            
+
             Interlocked.Decrement(ref this.asyncInProgress);
 
             if (result.Error != null)
@@ -277,7 +313,7 @@ namespace Microsoft.Live
 
             return session1 == session2;
         }
-        
+
         private static bool IsValidRedirectDomain(string redirectDomain)
         {
             if (!redirectDomain.StartsWith("https://", StringComparison.OrdinalIgnoreCase) &&


### PR DESCRIPTION
Make the call to LoginAsync easier.
Before the change, user has to create an IEnumerable<string> to passing in the scope like:
LoginAsync(new List<string>(){"wl.basic"});
Now, they can pass in the string directly:
LoginAsync("wl.basic", ...)
