### PR TITLE
Wrap up the live scopes into consts

### DIFF
--- a/src/Common/UnitTests/Operations/RefreshTokenOperationTest.cs
+++ b/src/Common/UnitTests/Operations/RefreshTokenOperationTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Live.UnitTests
 
             string clientId = "clientId";
             string refreshToken = "refreshToken";
-            IEnumerable<string> scopes = new string[]{ "wl.basic" };
+            IEnumerable<string> scopes = new string[]{ LiveScopes.Basic };
             SynchronizationContextWrapper syncContext = SynchronizationContextWrapper.Current;
 
             var refreshOperation =

--- a/src/WinStore/Samples/Windows/XAML/APIExplorer/MainPage.xaml.cs
+++ b/src/WinStore/Samples/Windows/XAML/APIExplorer/MainPage.xaml.cs
@@ -41,7 +41,11 @@ namespace APIExplorer
     /// </summary>
     public sealed partial class MainPage : Page
     {
-        private static readonly string[] scopes = new string[] { "wl.signin", "wl.basic", "wl.skydrive_update" };
+        private static readonly string[] scopes = new string[] { 
+            LiveScopes.Signin, 
+            LiveScopes.Basic, 
+            LiveScopes.SkydriveUpdate 
+        };
         private LiveAuthClient authClient;
         private LiveConnectClient liveClient;
 

--- a/src/WinStore/Samples/Windows/XAML/FileUploadDownload/MainPage.xaml.cs
+++ b/src/WinStore/Samples/Windows/XAML/FileUploadDownload/MainPage.xaml.cs
@@ -41,7 +41,11 @@ namespace FileUploadDownload
     /// </summary>
     public sealed partial class MainPage : Page
     {
-        private static readonly string[] scopes = new string[]{ "wl.signin", "wl.basic", "wl.skydrive_update" };
+        private static readonly string[] scopes = new string[]{ 
+            LiveScopes.Signin,
+            LiveScopes.Basic,
+            LiveScopes.SkydriveUpdate
+        };
 
         private LiveAuthClient authClient;
         private LiveConnectClient liveClient;
@@ -160,12 +164,12 @@ namespace FileUploadDownload
                     this.cts = new CancellationTokenSource();
 
                     LiveUploadOperation operation = await this.liveClient.CreateBackgroundUploadAsync(
-                        folderPath, 
-                        file.Name, 
-                        file, 
+                        folderPath,
+                        file.Name,
+                        file,
                         OverwriteOption.Rename);
                     LiveOperationResult result = await operation.StartAsync(
-                        this.cts.Token, 
+                        this.cts.Token,
                         progressHandler);
 
                     dynamic fileData = result.Result;
@@ -207,13 +211,13 @@ namespace FileUploadDownload
                 roamingSettings.Values["FileName"] = this.fileName;
 
                 var appSettingContainer = roamingSettings.CreateContainer(
-                    "FileUploadDownload Settings", 
+                    "FileUploadDownload Settings",
                     ApplicationDataCreateDisposition.Always);
                 appSettingContainer.Values[this.fileName] = true;
 
                 var roamingFolder = ApplicationData.Current.RoamingFolder;
                 var storageDir = await roamingFolder.CreateFolderAsync(
-                    "FileUploadDownload sample", 
+                    "FileUploadDownload sample",
                     CreationCollisionOption.OpenIfExists);
 
                 var storageFile =
@@ -229,7 +233,7 @@ namespace FileUploadDownload
                     this.cts = new CancellationTokenSource();
 
                     LiveDownloadOperation operation = await this.liveClient.CreateBackgroundDownloadAsync(
-                        fileLink, 
+                        fileLink,
                         storageFile);
                     LiveDownloadOperationResult result = await operation.StartAsync(this.cts.Token, progressHandler);
 

--- a/src/WinStore/Samples/Windows/XAML/StreamUploadDownload/MainPage.xaml.cs
+++ b/src/WinStore/Samples/Windows/XAML/StreamUploadDownload/MainPage.xaml.cs
@@ -43,7 +43,11 @@ namespace StreamUploadDownload
     /// </summary>
     public sealed partial class MainPage : Page
     {
-        private static readonly string[] scopes = new string[]{"wl.signin", "wl.basic", "wl.skydrive_update"};
+        private static readonly string[] scopes = new string[]{
+            LiveScopes.Signin,
+            LiveScopes.Basic,
+            LiveScopes.SkydriveUpdate
+        };
 
         private LiveAuthClient authClient;
         private LiveConnectClient liveClient;
@@ -163,11 +167,11 @@ namespace StreamUploadDownload
                             (progress) => { this.progressBar.Value = progress.ProgressPercentage; });
 
                         this.cts = new CancellationTokenSource();
-                        LiveUploadOperation operation = 
+                        LiveUploadOperation operation =
                             await this.liveClient.CreateBackgroundUploadAsync(
-                                folderPath, 
-                                file.Name, 
-                                inStream, 
+                                folderPath,
+                                file.Name,
+                                inStream,
                                 OverwriteOption.Rename);
                         LiveOperationResult result = await operation.StartAsync(this.cts.Token, progressHandler);
 

--- a/src/WinStore/Source/Microsoft.Live.WinStore.csproj
+++ b/src/WinStore/Source/Microsoft.Live.WinStore.csproj
@@ -222,6 +222,7 @@ NOTE: This file will NOT build inside of CoreXT. The enlistment does not support
     <Compile Include="..\..\Common\Source\Public\LiveConnectClientTaskAsync.cs">
       <Link>Public\LiveConnectClientTaskAsync.cs</Link>
     </Compile>
+    <Compile Include="Public\LiveScopes.cs" />
     <Compile Include="Public\LiveUploadOperation.cs" />
     <Compile Include="Public\LiveDownloadOperation.cs" />
     <Compile Include="Public\LiveDownloadOperationResult.cs" />

--- a/src/WinStore/Source/Public/LiveAuthClient.cs
+++ b/src/WinStore/Source/Public/LiveAuthClient.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Live
 
     public partial class LiveAuthClient
     {
-        private const string SignInOfferName = "wl.signin";
+        private const string SignInOfferName = LiveScopes.Signin;
         private List<string> currentScopes;
         private ThemeType? theme;
 

--- a/src/WinStore/Source/Public/LiveScopes.cs
+++ b/src/WinStore/Source/Public/LiveScopes.cs
@@ -1,0 +1,120 @@
+﻿
+namespace Microsoft.Live
+{
+    public static class LiveScopes
+    {
+        #region Core Scopes
+        /// <summary>
+        /// Enables read access to a user's basic profile info. Also enables read access to a user's list of contacts.
+        /// </summary>
+        public const string Basic = "wl.basic";
+
+        /// <summary>
+        /// Enables the ability of an app to read and update a user's info at any time. Without this scope, an app can access the user's info only while the user is signed in to Live Connect and is using your app. 
+        /// </summary>
+        public const string OfflineAccess = "wl.offline_access";
+
+        /// <summary>
+        /// Enables single sign-in behavior. With single sign-in, users who are already signed in to Live Connect are also signed in to your website.
+        /// </summary>
+        public const string Signin = "wl.signin";
+        #endregion
+
+        #region Extended Scopes
+        /// <summary>
+        /// Enables read access to a user's birthday info including birth day, month, and year.
+        /// </summary>
+        public const string Birthday = "wl.birthday";
+
+        /// <summary>
+        /// Enables read access to a user's calendars and events.
+        /// </summary>
+        public const string Calendars = "wl.calendars";
+
+        /// <summary>
+        /// Enables read and write access to a user's calendars and events.
+        /// </summary>
+        public const string CalendarsUpdate = "wl.calendars_update";
+
+        /// <summary>
+        /// Enables read access to the birth day and birth month of a user's contacts. Note that this also gives read access to the user's birth day, birth month, and birth year.
+        /// </summary>
+        public const string ContactsBirthday = "wl.contacts_birthday";
+
+        /// <summary>
+        /// Enables creation of new contacts in the user's address book.
+        /// </summary>
+        public const string ContactsCreate = "wl.contacts_create";
+
+        /// <summary>
+        /// Enables read access to a user's calendars and events. Also enables read access to any calendars and events that other users have shared with the user.
+        /// </summary>
+        public const string ContactsCalendars = "wl.contacts_calendars";
+
+        /// <summary>
+        /// Enables read access to a user's personal, preferred and business email addresses. Also enables read access to any personal, preferred and business email addresses that other users have shared with the user.
+        /// </summary>
+        public const string ContactsEmails = "wl.contacts_emails";
+
+        /// <summary>
+        /// Enables read access to a user's albums, photos, videos, and audio, and their associated comments and tags. Also enables read access to any albums, photos, videos, and audio that other users have shared with the user. 
+        /// </summary>
+        public const string ContactsPhotos = "wl.contacts_photos";
+
+        /// <summary>
+        /// Enables read access to Microsoft OneDrive files that other users have shared with the user. Note that this also gives read access to the user's files stored in OneDrive.
+        /// </summary>
+        public const string ContactsSkydrive = "wl.contacts_skydrive";
+
+        /// <summary>
+        /// Enables read access to a user's personal, preferred, and business email addresses.
+        /// </summary>
+        public const string Emails = "wl.emails";
+
+        /// <summary>
+        /// Enables creation of events on the user's default calendar.
+        /// </summary>
+        public const string EventsCreate = "wl.events_create";
+
+        /// <summary>
+        /// Enables read and write access to a user's email using IMAP, and send access using SMTP. 
+        /// </summary>
+        public const string IMAP = "wl.imap";
+
+        /// <summary>
+        /// Enables read access to a user's personal, business, and mobile phone numbers.
+        /// </summary>
+        public const string PhoneNumbers = "wl.phone_numbers";
+
+        /// <summary>
+        /// Enables read access to a user's photos, videos, audio, and albums.
+        /// </summary>
+        public const string Photos = "wl.photos";
+
+        /// <summary>
+        /// Enables read access to a user's postal addresses.
+        /// </summary>
+        public const string PostalAddresses = "wl.postal_addresses";
+
+        /// <summary>
+        /// Enables read access to a user's files stored in OneDrive.
+        /// </summary>
+        public const string Skydrive = "wl.skydrive";
+
+        /// <summary>
+        /// Enables read and write access to a user's files stored in OneDrive.
+        /// </summary>
+        public const string SkydriveUpdate = "wl.skydrive_update";
+
+        /// <summary>
+        /// Enables read access to a user's employer and work position information.
+        /// </summary>
+        public const string WorkProfile = "wl.work_profile";
+
+        /// <summary>
+        /// Enables read and write access to a user's OneNote notebooks stored in OneDrive.
+        /// </summary>
+        public const string OnenoteCreate = "office.onenote_create";
+        #endregion
+    }
+}

--- a/src/WinStore/Source/Public/LiveScopes.cs
+++ b/src/WinStore/Source/Public/LiveScopes.cs
@@ -1,4 +1,25 @@
-﻿
+﻿// ------------------------------------------------------------------------------
+// Copyright (c) 2014 Microsoft Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+// ------------------------------------------------------------------------------
+
 namespace Microsoft.Live
 {
     public static class LiveScopes


### PR DESCRIPTION
Wrap up the live scopes into consts according https://msdn.microsoft.com/en-us/library/hh243646.aspx.
Appending an additional one - wl.contacts_emails

Reasons:
1. Use the strings directly is typo prone.
2. Provides intellisense to show a list of all possible scopes.

For example:
Originally:
   IEnumerable<string> scopes = new string[]{ "wl.basic" };
Become:
   IEnumerable<string> scopes = new string[]{ LiveScopes.Basic };

It is backward compatible and can be used in mix as well.