### PR TITLE
 Fixed null reference exception when uploadOp is not created for upload

### DIFF
--- a/src/WinStore/Source/Internal/Operations/TailoredUploadOperation.cs
+++ b/src/WinStore/Source/Internal/Operations/TailoredUploadOperation.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Live.Operations
             {
                 try
                 {
-                    IInputStream responseStream = this.uploadOp.GetResultStreamAt(0);
+                    IInputStream responseStream = this.uploadOp == null ? null : this.uploadOp.GetResultStreamAt(0);
                     if (responseStream == null)
                     {
                         var error = new LiveConnectException(


### PR DESCRIPTION
This prevents a connection error getting masked by a null reference exception when an upload operation isn't created.