### PR TITLE
Bug: if you InitializeAsync in Windows desktop SDK a second time, you…

### DIFF
--- a/src/Desktop/Source/Internal/LiveAuthClientCore.cs
+++ b/src/Desktop/Source/Internal/LiveAuthClientCore.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Live
             if (this.loginStatus != null)
             {
                 // We have a result already, then return this one.
-                this.OnInitCompleted(null);
+				this.OnInitCompleted(this.loginStatus);
             }
             else
             {


### PR DESCRIPTION
… get a null exception because LiveAuthClientCore.ValidateSessionInitScopes does not allow a null parameter.

Fix: pass in the previously created loginStatus into OnInitCompleted, which passes it onto ValidateSessionInitScopes.  This also matches the existing comment on the previous line.